### PR TITLE
fix failing AAA Example 11.2.x

### DIFF
--- a/lighty-modules/lighty-aaa/pom.xml
+++ b/lighty-modules/lighty-aaa/pom.xml
@@ -43,9 +43,10 @@
             <artifactId>aaa-encrypt-service-impl</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-            <version>1.2</version>
+            <!-- Required only for 3rd-party libraries (especially commons-beanutils), that expect to call the commons
+                 logging APIs -->
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
         </dependency>
 
         <!-- Jersey + Jetty for RESTCONF -->


### PR DESCRIPTION
update wrong package of DataBroker used in AAALightyShiroProvider
add missing logger dependency used in commons-beanutils