### PR TITLE
Fixed failing tests and changed yangtools/mdsal/odlparent versions

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>org.opendaylight.odlparent</groupId>
                 <artifactId>odlparent</artifactId>
-                <version>6.0.7</version>
+                <version>6.0.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -62,7 +62,7 @@
             <dependency>
                 <groupId>org.opendaylight.mdsal</groupId>
                 <artifactId>mdsal-artifacts</artifactId>
-                <version>5.0.11</version>
+                <version>5.0.12</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -76,7 +76,7 @@
             <dependency>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yangtools-artifacts</artifactId>
-                <version>4.0.9</version>
+                <version>4.0.11</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-core/lighty-binding-parent/pom.xml
+++ b/lighty-core/lighty-binding-parent/pom.xml
@@ -54,7 +54,7 @@
             <plugin>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yang-maven-plugin</artifactId>
-                <version>4.0.9</version>
+                <version>4.0.11</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.opendaylight.mdsal</groupId>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -175,7 +175,7 @@
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>6.0.5</version>
+                            <version>6.0.9</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -192,7 +192,7 @@
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
                             <artifactId>spotbugs</artifactId>
-                            <version>6.0.5</version>
+                            <version>6.0.9</version>
                         </dependency>
                         <dependency>
                             <!-- The SpotBugs Maven plugin uses SLF4J 1.8 beta 2 -->


### PR DESCRIPTION
Changed versions of odlparent to 6.0.9 from 6.0.7,
yangtools from 4.0.9 to 4.0.11 and
mdsal from 5.0.11 to 5.0.12, as in ODL Git was
change for bumping versions of those artifacts
to current changed and lighty-core tests for
AbstractLightyModule and CommunityRestconfApp were
failing.

JIRA: PTDL-1153
Signed-off-by: Martin Bugan <martin.bugan@pantheon.tech>