### PR TITLE
Bumping checkstyle version

### DIFF
--- a/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/Deserializer.java
+++ b/lighty-core/lighty-codecs/src/main/java/io/lighty/codecs/api/Deserializer.java
@@ -26,8 +26,7 @@ public interface Deserializer<BA extends DataObject> {
     /**
      * Deserialize Binding Independent identifier FROM Binding Aware identifier.
      *
-     * @param identifier
-     *            - Binding Aware identifier to be deserialized
+     * @param identifier Binding Aware identifier to be deserialized
      * @return deserialized Binding Independent identifier
      */
     YangInstanceIdentifier deserializeIdentifier(InstanceIdentifier<BA> identifier);
@@ -37,10 +36,8 @@ public interface Deserializer<BA extends DataObject> {
     /**
      * Deserialize Binding Independent data FROM Binding Aware data.
      *
-     * @param identifier
-     *            - identifier of Binding Aware data
-     * @param data
-     *            - Binding Aware data to be deserialized
+     * @param identifier Identifier of Binding Aware data
+     * @param data Binding Aware data to be deserialized
      * @return deserialized Binding Independent data with Binding Independent identifier wrapped in {@link Entry}
      */
     Entry<YangInstanceIdentifier, NormalizedNode<?, ?>> convertToNormalizedNode(InstanceIdentifier<BA> identifier,
@@ -49,8 +46,7 @@ public interface Deserializer<BA extends DataObject> {
     /**
      * Deserialize Binding Independent RPC data(input/output) FROM Binding Aware RPC data(input/output).
      *
-     * @param rpcData
-     *            - Binding Aware RPC data to be deserialized
+     * @param rpcData Binding Aware RPC data to be deserialized
      * @return deserialized Binding Independent RPC data
      */
     ContainerNode convertToBindingIndependentRpc(DataContainer rpcData);
@@ -59,8 +55,7 @@ public interface Deserializer<BA extends DataObject> {
      * Deserialize Binding Independent Notification data(input/output) FROM Binding Aware Notification
      * data(input/output).
      *
-     * @param notificationData
-     *            - Binding Aware Notification data to be deserialized
+     * @param notificationData Binding Aware Notification data to be deserialized
      * @return deserialized Binding Independent Notification data
      */
     ContainerNode convertToBindingIndependentNotification(Notification notificationData);

--- a/lighty-core/lighty-common/src/main/java/io/lighty/core/common/models/YangModuleUtils.java
+++ b/lighty-core/lighty-common/src/main/java/io/lighty/core/common/models/YangModuleUtils.java
@@ -32,8 +32,7 @@ public final class YangModuleUtils {
 
     /**
      * Get all Yang modules from classpath using ServiceLoader scanning.
-     * @return
-     *   Complete list of models found on classpath.
+     * @return Complete list of models found on classpath.
      */
     public static Set<YangModuleInfo> getAllModelsFromClasspath() {
         Set<YangModuleInfo> moduleInfos = new HashSet<>();
@@ -48,10 +47,8 @@ public final class YangModuleUtils {
     /**
      * Filter top-level models from given entry set.
      * Top level model is considered the model which is never used as dependency for other model.
-     * @param models
-     *    Unfiltered entry set of models.
-     * @return
-     *    Filtered set of top-level models only.
+     * @param models Unfiltered entry set of models.
+     * @return Filtered set of top-level models only.
      */
     public static Set<YangModuleInfo> filterTopLevelModels(final Set<YangModuleInfo> models) {
         Set<YangModuleInfo> result = new HashSet<>();
@@ -66,10 +63,8 @@ public final class YangModuleUtils {
     /**
      * Filter unique models from given entry set.
      * This filter scans recursively dependencies and returns minimal set of models that are unique.
-     * @param models
-     *   Unfiltered entry set of models.
-     * @return
-     *   Filtered set of unique models only.
+     * @param models Unfiltered entry set of models.
+     * @return Filtered set of unique models only.
      */
     public static Set<YangModuleInfo> filterUniqueModels(final Collection<YangModuleInfo> models) {
         Map<ModuleId, YangModuleInfo> result = new HashMap<>();

--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/api/AbstractLightyModule.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/api/AbstractLightyModule.java
@@ -134,8 +134,7 @@ public abstract class AbstractLightyModule implements LightyModule {
     /**
      * Start and block until shutdown is requested.
      * @param initFinishCallback callback that will be called after start is completed.
-     * @throws InterruptedException
-     *   thrown in case module initialization fails.
+     * @throws InterruptedException thrown in case module initialization fails.
      */
     public void startBlocking(final Consumer<Boolean> initFinishCallback) throws InterruptedException {
         Futures.addCallback(start(), new FutureCallback<Boolean>() {

--- a/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/util/ControllerConfigUtils.java
+++ b/lighty-core/lighty-controller/src/main/java/io/lighty/core/controller/impl/util/ControllerConfigUtils.java
@@ -82,12 +82,10 @@ public final class ControllerConfigUtils {
 
     /**
      * Read configuration from InputStream representing JSON configuration data.
-     * @param jsonConfigInputStream
-     *   InputStream representing JSON configuration.
-     * @return
-     *   Instance of LightyController configuration data.
-     * @throws ConfigurationException
-     *   Thrown in case that JSON configuration is not readable or incorrect, or yang model resources cannot be loaded.
+     * @param jsonConfigInputStream InputStream representing JSON configuration.
+     * @return Instance of LightyController configuration data.
+     * @throws ConfigurationException Thrown in case that JSON configuration is not readable or incorrect, or yang
+     *                                model resources cannot be loaded.
      */
     public static ControllerConfiguration getConfiguration(final InputStream jsonConfigInputStream)
             throws ConfigurationException {
@@ -186,8 +184,7 @@ public final class ControllerConfigUtils {
 
     /**
      * Get typical single node configuration with default model set.
-     * @return
-     *   Instance of LightyController configuration data.
+     * @return Instance of LightyController configuration data.
      * @throws ConfigurationException if unable to find akka config files
      */
     public static ControllerConfiguration getDefaultSingleNodeConfiguration()
@@ -197,10 +194,8 @@ public final class ControllerConfigUtils {
 
     /**
      * Get typical single node configuration with custom model set.
-     * @param additionalModels
-     *    List of models which is used in addition to default model set.
-     * @return
-     *    Instance of LightyController configuration data.
+     * @param additionalModels List of models which is used in addition to default model set.
+     * @return Instance of LightyController configuration data.
      * @throws ConfigurationException if unable to find akka config files
      */
     public static ControllerConfiguration getDefaultSingleNodeConfiguration(final Set<YangModuleInfo> additionalModels)

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -18,7 +18,6 @@
 
     <!-- This is the main parent for building LightyModule jars. -->
 
-    <groupId>io.lighty.core</groupId>
     <artifactId>lighty-parent</artifactId>
     <packaging>pom</packaging>
 
@@ -159,18 +158,18 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.1.1</version>
                     <dependencies>
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
                             <!-- This should match the dependency management on com.puppycrawl.tools:checkstyle above -->
-                            <version>8.26</version>
+                            <version>8.34</version>
                         </dependency>
                         <dependency>
                             <groupId>com.github.sevntu-checkstyle</groupId>
                             <artifactId>sevntu-checks</artifactId>
-                            <version>1.36.0</version>
+                            <version>1.37.1</version>
                         </dependency>
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>

--- a/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/NetconfSBPlugin.java
+++ b/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/NetconfSBPlugin.java
@@ -18,8 +18,7 @@ public interface NetconfSBPlugin extends LightyModule {
 
     /**
      * Indicates if this instance is clustered or not.
-     * @return
-     *   True if this instance of NETCONF SBP is clustered, false otherwise.
+     * @return True if this instance of NETCONF SBP is clustered, false otherwise.
      */
     boolean isClustered();
 

--- a/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/util/RestConfConfigUtils.java
+++ b/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/util/RestConfConfigUtils.java
@@ -46,12 +46,10 @@ public final class RestConfConfigUtils {
 
     /**
      * Load restconf configuration from InputStream containing JSON data.
-     * @param jsonConfigInputStream
-     *   InputStream containing RestConf configuration data in JSON format.
-     * @return
-     *   Object representation of configuration data.
-     * @throws ConfigurationException
-     *   In case InputStream does not contain valid JSON data or cannot bind Json tree to type.
+     * @param jsonConfigInputStream InputStream containing RestConf configuration data in JSON format.
+     * @return Object representation of configuration data.
+     * @throws ConfigurationException In case InputStream does not contain valid JSON data or cannot bind Json tree
+     *                                to type.
      */
     public static RestConfConfiguration getRestConfConfiguration(final InputStream jsonConfigInputStream)
             throws ConfigurationException {
@@ -81,14 +79,12 @@ public final class RestConfConfigUtils {
     /**
      * Load restconf configuration from InputStream containing JSON data and use lightyServices to
      * get references to necessary Lighty services.
-     * @param jsonConfigInputStream
-     *   InputStream containing RestConf configuration data in JSON format.
-     * @param lightyServices
-     *   This object instace contains references to initialized Lighty services required for RestConf.
-     * @return
-     *   Object representation of configuration data.
-     * @throws ConfigurationException
-     *   In case InputStream does not contain valid JSON data or cannot bind Json tree to type.
+     * @param jsonConfigInputStream InputStream containing RestConf configuration data in JSON format.
+     * @param lightyServices This object instace contains references to initialized Lighty services required for
+     *                       RestConf.
+     * @return Object representation of configuration data.
+     * @throws ConfigurationException In case InputStream does not contain valid JSON data or cannot bind Json tree
+     *                                to type.
      */
     public static RestConfConfiguration getRestConfConfiguration(final InputStream jsonConfigInputStream,
             final LightyServices lightyServices) throws ConfigurationException {
@@ -125,12 +121,10 @@ public final class RestConfConfigUtils {
     /**
      * Copy existing RestConf configuration and use provided lightyServices
      * to populate references to necessary Lighty services.
-     * @param restConfConfiguration
-     *   Object representation of configuration data.
-     * @param lightyServices
-     *   This object instace contains references to initialized Lighty services required for RestConf.
-     * @return
-     *   Object representation of configuration data.
+     * @param restConfConfiguration Object representation of configuration data.
+     * @param lightyServices This object instace contains references to initialized Lighty services required for
+     *                       RestConf.
+     * @return Object representation of configuration data.
      */
     public static RestConfConfiguration getRestConfConfiguration(final RestConfConfiguration restConfConfiguration,
             final LightyServices lightyServices) {
@@ -147,10 +141,9 @@ public final class RestConfConfigUtils {
 
     /**
      * Get default RestConf configuration using provided Lighty services.
-     * @param lightyServices
-     *   This object instace contains references to initialized Lighty services required for RestConf.
-     * @return
-     *   Object representation of configuration data.
+     * @param lightyServices This object instace contains references to initialized Lighty services required for
+     *                       RestConf.
+     * @return Object representation of configuration data.
      */
     public static RestConfConfiguration getDefaultRestConfConfiguration(final LightyServices lightyServices) {
         return new RestConfConfiguration(
@@ -162,8 +155,7 @@ public final class RestConfConfigUtils {
 
     /**
      * Get default RestConf configuration, Lighty services are not populated in this configuration.
-     * @return
-     *   Object representation of configuration data.
+     * @return Object representation of configuration data.
      */
     public static RestConfConfiguration getDefaultRestConfConfiguration() {
         return new RestConfConfiguration();

--- a/lighty-modules/lighty-restconf-nb-community/src/test/java/io/lighty/modules/northbound/restconf/community/impl/tests/RestConfConfigurationTest.java
+++ b/lighty-modules/lighty-restconf-nb-community/src/test/java/io/lighty/modules/northbound/restconf/community/impl/tests/RestConfConfigurationTest.java
@@ -14,7 +14,6 @@ import io.lighty.modules.northbound.restconf.community.impl.config.RestConfConfi
 import io.lighty.modules.northbound.restconf.community.impl.util.RestConfConfigUtils;
 import java.io.InputStream;
 import java.net.InetAddress;
-
 import org.testng.Assert;
 import org.testng.annotations.Test;
 


### PR DESCRIPTION
Increasing maven-checkstyle-plugin version from 3.1.0 to 3.1.1, checkstyle dependency 8.26 to 8.34
sevntu-checks from 1.36.0 to 1.37.1 and odl checkstyle from 6.0.5 to 7.0.5 it is in odl-parent

Signed-off-by: Peter Valka <Peter.Valka@pantheon.tech>