### PR TITLE
Update versions to track Mg SR2 snapshots

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>org.opendaylight.odlparent</groupId>
                 <artifactId>odlparent</artifactId>
-                <version>6.0.10</version>
+                <version>6.0.11</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -62,7 +62,7 @@
             <dependency>
                 <groupId>org.opendaylight.mdsal</groupId>
                 <artifactId>mdsal-artifacts</artifactId>
-                <version>5.0.13</version>
+                <version>5.0.14</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -74,24 +74,23 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>org.opendaylight.yangtools</groupId>
-                <artifactId>yangtools-artifacts</artifactId>
-                <version>4.0.12</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
-            <dependency>
                 <groupId>org.opendaylight.openflowplugin</groupId>
                 <artifactId>openflowplugin-artifacts</artifactId>
-                <version>0.10.1</version>
+                <version>0.10.2-SNAPSHOT</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>org.opendaylight.serviceutils</groupId>
                 <artifactId>serviceutils-artifacts</artifactId>
-                <version>0.5.1</version>
+                <version>0.5.2-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.opendaylight.yangtools</groupId>
+                <artifactId>yangtools-artifacts</artifactId>
+                <version>4.0.13</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-core/lighty-binding-parent/pom.xml
+++ b/lighty-core/lighty-binding-parent/pom.xml
@@ -54,12 +54,12 @@
             <plugin>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yang-maven-plugin</artifactId>
-                <version>4.0.12</version>
+                <version>4.0.13</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.opendaylight.mdsal</groupId>
                         <artifactId>maven-sal-api-gen-plugin</artifactId>
-                        <version>3.0.13</version>
+                        <version>3.0.14</version>
                         <type>jar</type>
                     </dependency>
                 </dependencies>

--- a/lighty-core/lighty-parent/pom.xml
+++ b/lighty-core/lighty-parent/pom.xml
@@ -175,7 +175,7 @@
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>6.0.10</version>
+                            <version>6.0.11</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -192,7 +192,7 @@
                         <dependency>
                             <groupId>org.opendaylight.odlparent</groupId>
                             <artifactId>spotbugs</artifactId>
-                            <version>6.0.10</version>
+                            <version>6.0.11</version>
                         </dependency>
                         <dependency>
                             <!-- The SpotBugs Maven plugin uses SLF4J 1.8 beta 2 -->


### PR DESCRIPTION
Upstream has had some more updates, adjust to that. Also fix references
to serviceutils/openflowplugin.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>