### PR TITLE
Updated preconditions for NetconfNmdaBaseServiceImpl delete-config 12.2.x

### DIFF
--- a/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/NetconfNmdaBaseServiceImpl.java
+++ b/lighty-modules/lighty-netconf-sb/src/main/java/io/lighty/modules/southbound/netconf/impl/NetconfNmdaBaseServiceImpl.java
@@ -9,6 +9,7 @@ package io.lighty.modules.southbound.netconf.impl;
 
 import static java.util.Objects.requireNonNull;
 import static org.opendaylight.netconf.sal.connect.netconf.util.NetconfMessageTransformUtil.NETCONF_OPERATION_QNAME;
+import static org.opendaylight.netconf.sal.connect.netconf.util.NetconfMessageTransformUtil.NETCONF_RUNNING_QNAME;
 import static org.opendaylight.netconf.sal.connect.netconf.util.NetconfMessageTransformUtil.toId;
 import static org.opendaylight.netconf.sal.connect.netconf.util.NetconfMessageTransformUtil.toPath;
 
@@ -26,6 +27,7 @@ import org.opendaylight.mdsal.dom.api.DOMRpcResult;
 import org.opendaylight.mdsal.dom.api.DOMRpcService;
 import org.opendaylight.netconf.api.ModifyAction;
 import org.opendaylight.netconf.sal.connect.netconf.util.NetconfMessageTransformUtil;
+import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.datastores.rev180214.Running;
 import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.netconf.nmda.rev190107.edit.data.input.EditContent;
 import org.opendaylight.yang.gen.v1.urn.tbd.params.xml.ns.yang.network.topology.rev131021.NodeId;
 import org.opendaylight.yangtools.rfc7952.data.api.NormalizedMetadata;
@@ -184,6 +186,14 @@ public class NetconfNmdaBaseServiceImpl extends NetconfBaseServiceImpl implement
                         getDatastoreNode(requireNonNull(targetDatastore)),
                         getDefaultOperationNode(defaultModifyAction.orElseThrow(() ->
                                 new NoSuchElementException("Default Modify Action is missing"))), editStructure));
+    }
+
+    @Override
+    public ListenableFuture<DOMRpcResult> deleteConfig(QName targetDatastore) {
+        if (Running.QNAME.equals(targetDatastore)) {
+            targetDatastore = NETCONF_RUNNING_QNAME;
+        }
+        return super.deleteConfig(targetDatastore);
     }
 
     private DataContainerChild<?, ?> getDatastoreNode(QName datastore) {


### PR DESCRIPTION
Update in branch 12.2.x, cherry-picked from master, changed
return value for deleteConfig acorrding the base class 
NetconfBaseServiceImpl in 12.2.x.

Updated preconditions for targetDatastore when calling delete-config
on NetconfNmdaBaseServiceImpl, because according to RFC6241
delete-config can't be called with Running datastore as target.

NetconfNmdaBaseService is extension to NetconfBaseService in lighty,
where are RFC6241 methods like edit-config, get-config etc. implemented.

Nmda implements two new methods from RFC8526 for
extended datastore types from RFC 8342, so as is understood by me,
NetconfBaseService methods for edit, get, delete are applicable
for older types of datastores used before new NMDA RFC
and those new are used for the new ones.

As the NetconfNmdaBaseService extends NetconfBaseService,
override of delete-config is probably the best choice to check
if target datastore is not Running QName from the ietf-datastores
and if it is, it's replaced by older Running QName and then
called parent method, so expecting Preconditions check error.