### PR TITLE
Fix creation of ServicesWrapper

### DIFF
--- a/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/CommunityRestConf.java
+++ b/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/CommunityRestConf.java
@@ -10,6 +10,7 @@ package io.lighty.modules.northbound.restconf.community.impl;
 import com.google.common.base.Throwables;
 import io.lighty.core.controller.api.AbstractLightyModule;
 import io.lighty.modules.northbound.restconf.community.impl.config.JsonRestConfServiceType;
+import io.lighty.modules.northbound.restconf.community.impl.util.RestConfConfigUtils;
 import io.lighty.server.LightyServerBuilder;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -41,6 +42,7 @@ import org.opendaylight.restconf.nb.rfc8040.handlers.RpcServiceHandler;
 import org.opendaylight.restconf.nb.rfc8040.handlers.SchemaContextHandler;
 import org.opendaylight.restconf.nb.rfc8040.handlers.TransactionChainHandler;
 import org.opendaylight.restconf.nb.rfc8040.services.wrapper.ServicesWrapper;
+import org.opendaylight.restconf.nb.rfc8040.streams.Configuration;
 import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.inet.types.rev130715.IpAddressBuilder;
 import org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.inet.types.rev130715.PortNumber;
 import org.opendaylight.yangtools.yang.common.Uint16;
@@ -133,9 +135,10 @@ public class CommunityRestConf extends AbstractLightyModule {
         final ActionServiceHandler actionServiceHandler = new ActionServiceHandler(this.domActionService);
         final NotificationServiceHandler notificationServiceHandler = new NotificationServiceHandler(
                 this.domNotificationService);
+        final Configuration streamsConfiguration = RestConfConfigUtils.getStreamsConfiguration();
         final ServicesWrapper servicesWrapper = ServicesWrapper.newInstance(schemaCtxHandler,
                 domMountPointServiceHandler, transactionChainHandler, domDataBrokerHandler, rpcServiceHandler,
-                actionServiceHandler, notificationServiceHandler, this.domSchemaService);
+                actionServiceHandler, notificationServiceHandler, this.domSchemaService, streamsConfiguration);
 
         ServletHolder jaxrs = null;
 

--- a/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/util/RestConfConfigUtils.java
+++ b/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/util/RestConfConfigUtils.java
@@ -17,6 +17,7 @@ import io.lighty.modules.northbound.restconf.community.impl.config.RestConfConfi
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Set;
+import org.opendaylight.restconf.nb.rfc8040.streams.Configuration;
 import org.opendaylight.yangtools.yang.binding.YangModuleInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,6 +34,11 @@ public final class RestConfConfigUtils {
             org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.restconf.monitoring.rev170126
                     .$YangModuleInfoImpl.getInstance()
             );
+    public static final int MAXIMUM_FRAGMENT_LENGTH = 0;
+    public static final int IDLE_TIMEOUT =  30000;
+    public static final int HEARTBEAT_INTERVAL = 10000;
+    public static final boolean USE_SSE = true;
+
 
     private RestConfConfigUtils() {
         throw new UnsupportedOperationException();
@@ -161,5 +167,9 @@ public final class RestConfConfigUtils {
      */
     public static RestConfConfiguration getDefaultRestConfConfiguration() {
         return new RestConfConfiguration();
+    }
+
+    public static Configuration getStreamsConfiguration() {
+        return new Configuration(MAXIMUM_FRAGMENT_LENGTH, IDLE_TIMEOUT, HEARTBEAT_INTERVAL, USE_SSE);
     }
 }


### PR DESCRIPTION
To constructor was added additional Configuration parameter, fix upstream changes,
create util method in RestConfConfigUtils to create Configuration with default values
as they are used in upstream

Signed-off-by: Peter Valka <Peter.Valka@pantheon.tech>