### PR TITLE
Fix #531: Add YANG models for notifications support

### DIFF
--- a/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/util/RestConfConfigUtils.java
+++ b/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/util/RestConfConfigUtils.java
@@ -31,7 +31,13 @@ public final class RestConfConfigUtils {
             org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.restconf.rev170126
                     .$YangModuleInfoImpl.getInstance(),
             org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.restconf.monitoring.rev170126
-                    .$YangModuleInfoImpl.getInstance()
+                    .$YangModuleInfoImpl.getInstance(),
+            org.opendaylight.yang.gen.v1.urn.opendaylight.params.xml.ns.yang.controller.md.sal.remote.rev140114
+                    .$YangModuleInfoImpl.getInstance(),
+            org.opendaylight.yang.gen.v1.urn.sal.restconf.event.subscription.rev140708
+                    .$YangModuleInfoImpl.getInstance(),
+            org.opendaylight.yang.gen.v1.subscribe.to.notification.rev161028.$YangModuleInfoImpl
+                    .getInstance()
             );
 
     private RestConfConfigUtils() {


### PR DESCRIPTION
Fix #531: Add YANG models for notifications support

- add sal-remote model
- add sal-remote-augment model
- add subscribe-to-notification model

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>