### PR TITLE
Fix #531: Add YANG models for notifications support

### DIFF
--- a/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/util/RestConfConfigUtils.java
+++ b/lighty-modules/lighty-restconf-nb-community/src/main/java/io/lighty/modules/northbound/restconf/community/impl/util/RestConfConfigUtils.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 public final class RestConfConfigUtils {
 
     private static final Logger LOG = LoggerFactory.getLogger(RestConfConfigUtils.class);
+
     public static final String RESTCONF_CONFIG_ROOT_ELEMENT_NAME = "restconf";
     public static final Set<YangModuleInfo> YANG_MODELS = ImmutableSet.of(
             org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.yang.library.rev160621
@@ -32,13 +33,18 @@ public final class RestConfConfigUtils {
             org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.restconf.rev170126
                     .$YangModuleInfoImpl.getInstance(),
             org.opendaylight.yang.gen.v1.urn.ietf.params.xml.ns.yang.ietf.restconf.monitoring.rev170126
-                    .$YangModuleInfoImpl.getInstance()
+                    .$YangModuleInfoImpl.getInstance(),
+            org.opendaylight.yang.gen.v1.urn.opendaylight.params.xml.ns.yang.controller.md.sal.remote.rev140114
+                    .$YangModuleInfoImpl.getInstance(),
+            org.opendaylight.yang.gen.v1.urn.sal.restconf.event.subscription.rev140708
+                    .$YangModuleInfoImpl.getInstance(),
+            org.opendaylight.yang.gen.v1.subscribe.to.notification.rev161028.$YangModuleInfoImpl
+                    .getInstance()
             );
     public static final int MAXIMUM_FRAGMENT_LENGTH = 0;
     public static final int IDLE_TIMEOUT =  30000;
     public static final int HEARTBEAT_INTERVAL = 10000;
     public static final boolean USE_SSE = true;
-
 
     private RestConfConfigUtils() {
         throw new UnsupportedOperationException();


### PR DESCRIPTION
Fix #531: Add YANG models for notifications support

- add sal-remote model
- add sal-remote-augment model
- add subscribe-to-notification model

Signed-off-by: Ivan Hrasko <ivan.hrasko@pantheon.tech>