### PR TITLE
Bump yangtools to 3.0.17

### DIFF
--- a/lighty-core/dependency-versions/pom.xml
+++ b/lighty-core/dependency-versions/pom.xml
@@ -83,7 +83,7 @@
             <dependency>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yangtools-artifacts</artifactId>
-                <version>3.0.16</version>
+                <version>3.0.17</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/lighty-core/lighty-binding-parent/pom.xml
+++ b/lighty-core/lighty-binding-parent/pom.xml
@@ -54,7 +54,7 @@
             <plugin>
                 <groupId>org.opendaylight.yangtools</groupId>
                 <artifactId>yang-maven-plugin</artifactId>
-                <version>3.0.16</version>
+                <version>3.0.17</version>
                 <dependencies>
                     <dependency>
                         <groupId>org.opendaylight.mdsal</groupId>


### PR DESCRIPTION
Newer YANG Tools have a few fixes as well as footprint optimizations
for YANG tokenization. Pick them into our proper.

Signed-off-by: Robert Varga <robert.varga@pantheon.tech>