### PR TITLE
Change travis url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Software-Defined Networking (SDN) solutions in Java. Developed by [PANTHEON.tech
 
 It utilizes core [OpenDaylight](https://www.opendaylight.org/) components, which are available as a set of libraries and are adapted to run in a __plain Java SE environment__.
 
-[![Build Status](https://travis-ci.org/PANTHEONtech/lighty-core.svg?branch=11.3.x)](https://travis-ci.org/PANTHEONtech/lighty-core)
+[![Build Status](https://travis-ci.com/PANTHEONtech/lighty-core.svg?branch=11.3.x)](https://travis-ci.com/PANTHEONtech/lighty-core)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.lighty.core/lighty-bom/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.lighty.core/lighty-bom)
 [![License](https://img.shields.io/badge/License-EPL%201.0-blue.svg)](https://opensource.org/licenses/EPL-1.0)
 


### PR DESCRIPTION
Updated url to point to travis-ci.com instead of old travis-ci.org

Signed-off-by: Peter Valka <Peter.Valka@pantheon.tech>