### PR TITLE
Update examples parents to contain start script 12.2.x

### DIFF
--- a/lighty-core/lighty-app-parent/pom.xml
+++ b/lighty-core/lighty-app-parent/pom.xml
@@ -46,6 +46,10 @@
         </dependency>
         <dependency>
             <groupId>io.lighty.resources</groupId>
+            <artifactId>start-script</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.lighty.resources</groupId>
             <artifactId>controller-application-assembly</artifactId>
             <scope>provided</scope>
         </dependency>
@@ -163,6 +167,23 @@
                                     <includeGroupIds>io.lighty.resources</includeGroupIds>
                                     <includeArtifactIds>singlenode-configuration</includeArtifactIds>
                                     <excludes>META-INF\/**</excludes>
+                                    <excludeTransitive>true</excludeTransitive>
+                                    <!-- Other resources belong to the package. -->
+                                    <outputDirectory>${project.build.directory}/assembly/resources</outputDirectory>
+                                    <silent>${lighty.silent.unpack}</silent>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>unpack-start-script</id>
+                                <goals>
+                                    <goal>unpack-dependencies</goal>
+                                </goals>
+                                <phase>prepare-package</phase>
+                                <configuration>
+                                    <includeGroupIds>io.lighty.resources</includeGroupIds>
+                                    <includeArtifactIds>start-script</includeArtifactIds>
+                                    <excludes>META-INF\/**</excludes>
+                                    <includes>*.sh</includes>
                                     <excludeTransitive>true</excludeTransitive>
                                     <!-- Other resources belong to the package. -->
                                     <outputDirectory>${project.build.directory}/assembly/resources</outputDirectory>

--- a/lighty-core/lighty-bom/pom.xml
+++ b/lighty-core/lighty-bom/pom.xml
@@ -95,6 +95,11 @@
                 <artifactId>singlenode-configuration</artifactId>
                 <version>12.2.1-SNAPSHOT</version>
             </dependency>
+            <dependency>
+                <groupId>io.lighty.resources</groupId>
+                <artifactId>start-script</artifactId>
+                <version>12.2.1-SNAPSHOT</version>
+            </dependency>
 
             <!-- Dependencies and resources which should not normally leak into production -->
             <dependency>

--- a/lighty-examples/lighty-community-aaa-restconf-app/pom.xml
+++ b/lighty-examples/lighty-community-aaa-restconf-app/pom.xml
@@ -42,7 +42,6 @@
             <groupId>io.lighty.resources</groupId>
             <artifactId>singlenode-configuration</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>

--- a/lighty-examples/lighty-community-aaa-restconf-app/src/main/assembly/resources/start-controller.sh
+++ b/lighty-examples/lighty-community-aaa-restconf-app/src/main/assembly/resources/start-controller.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-#start controller with java 11
-java -jar lighty-community-aaa-restconf-app-12.2.1-SNAPSHOT.jar
-

--- a/lighty-examples/lighty-community-restconf-netconf-app/src/main/assembly/resources/start-controller.sh
+++ b/lighty-examples/lighty-community-restconf-netconf-app/src/main/assembly/resources/start-controller.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-#start controller with java 11 or later
-#java --add-modules java.xml.bind -jar lighty-community-restconf-netconf-app-12.2.1-SNAPSHOT.jar sampleConfigSingleNode.json

--- a/lighty-examples/lighty-community-restconf-ofp-app/src/main/assembly/resources/start-ofp.sh
+++ b/lighty-examples/lighty-community-restconf-ofp-app/src/main/assembly/resources/start-ofp.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-# Starts application with default settings
-# alpn-boot version depends on java version 
-java -jar lighty-community-restconf-ofp-app-12.2.1-SNAPSHOT.jar

--- a/lighty-resources/start-script/pom.xml
+++ b/lighty-resources/start-script/pom.xml
@@ -7,22 +7,20 @@
   and is available at https://www.eclipse.org/legal/epl-v10.html
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.lighty.resources</groupId>
-    <artifactId>lighty-resources-aggregator</artifactId>
-    <packaging>pom</packaging>
+  <parent>
+    <groupId>io.lighty.core</groupId>
+    <artifactId>lighty-parent</artifactId>
     <version>12.2.1-SNAPSHOT</version>
+    <relativePath>../../lighty-core/lighty-parent</relativePath>
+  </parent>
 
-    <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
-        <maven.install.skip>true</maven.install.skip>
-    </properties>
+  <groupId>io.lighty.resources</groupId>
+  <artifactId>start-script</artifactId>
+  <packaging>jar</packaging>
 
-    <modules>
-        <module>log4j-properties</module>
-        <module>singlenode-configuration</module>
-        <module>controller-application-assembly</module>
-        <module>start-script</module>
-    </modules>
+  <name>${project.groupId}:${project.artifactId}</name>
+  <url>https://github.com/PANTHEONtech/lighty-core</url>
+
 </project>

--- a/lighty-resources/start-script/src/main/resources/start-controller.sh
+++ b/lighty-resources/start-script/src/main/resources/start-controller.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Set JAVA_HOME to point to a specific Java 11+ JDK
+#export JAVA_HOME=/usr/lib/jvm/java-1.11.0-openjdk-amd64
+
+# If JAVA_HOME is not set, try to find it using java itself
+if [ -z ${JAVA_HOME} ]; then
+	command -v java >/dev/null 2>&1 || { echo >&2 "java is required, but it's not installed. Set JAVA_HOME or add java to your path."; exit 1; }
+	JAVA_HOME=`java -XshowSettings:properties -version 2>&1 > /dev/null | grep 'java.home' | sed -e 's/^.*java.home = \(.*\)$/\1/'`
+fi;
+
+# Make sure we are using Java 11+
+JAVA_VERSION=`${JAVA_HOME}/bin/java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1`
+if [ -z ${JAVA_VERSION} ] || [ ${JAVA_VERSION} -lt 11 ]; then
+        echo "Java 11+ is required to run this application!"
+        exit -1
+fi;
+
+# Find out lighty application name and version number
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+JAR_FILE=`ls -1 "${SCRIPT_DIR}" | grep .jar | head -n1`
+APP_NAME=`echo "${JAR_FILE}" | sed -e 's/^\(.*\)-\([0-9]\+\.[0-9]\+\.[0-9]\+\)\(-SNAPSHOT\)\?\(-javadoc\)\?\.jar$/\1/'`
+APP_VERSION=`echo "${JAR_FILE}" | sed -e 's/^.*-\([0-9]\+\.[0-9]\+\.[0-9]\+\)\(-SNAPSHOT\)\?\(-javadoc\)\?\.jar$/\1\2/'`
+
+# Run the application
+( cd "${SCRIPT_DIR}" && ${JAVA_HOME}/bin/java -jar "${APP_NAME}-${APP_VERSION}.jar" $* )


### PR DESCRIPTION
Updated lighty-app-parent to redistribute
start-controller.sh script from lighty-resources
to all examples zip distributions.

Signed-off-by: Martin Bugan <martin.bugan@pantheon.tech>